### PR TITLE
refactor: ConsumerRecordConverter to not pass OffsetInfo

### DIFF
--- a/src/main/java/com/gojek/beast/protomapping/UnknownProtoFields.java
+++ b/src/main/java/com/gojek/beast/protomapping/UnknownProtoFields.java
@@ -14,7 +14,7 @@ public class UnknownProtoFields {
         try {
             convertedFields = UnknownFieldSet.parseFrom(message).toString();
         } catch (InvalidProtocolBufferException e) {
-            log.warn("invalid byte representation of a protobuf message");
+            log.warn("invalid byte representation of a protobuf message: {}", new String(message));
         }
         return convertedFields;
     }

--- a/src/main/java/com/gojek/beast/sink/bq/BqSink.java
+++ b/src/main/java/com/gojek/beast/sink/bq/BqSink.java
@@ -85,7 +85,7 @@ public class BqSink implements Sink {
         InsertAllRequest rows = builder.build();
         InsertAllResponse response = bigquery.insertAll(rows);
 
-        log.info("Pushing {} records to BQ. Contains failed?: {}", records.size(), !response.hasErrors());
+        log.info("Pushed a batch of {} records to BQ. Insert success?: {}", records.size(), !response.hasErrors());
         statsClient.count("bq.sink.push.records", records.size());
         statsClient.timeIt("bq.sink.push.time", start);
         return response;

--- a/src/main/java/com/gojek/beast/sink/dlq/gcs/GCSErrorWriter.java
+++ b/src/main/java/com/gojek/beast/sink/dlq/gcs/GCSErrorWriter.java
@@ -59,7 +59,7 @@ public class GCSErrorWriter implements ErrorWriter {
         //serialize the messages in GCS for each topic - a file with all messages per topic is stored in GCS
         topicMessagesMap.keySet().forEach(topicName -> {
             final String fileName = UUID.randomUUID().toString();
-            final String pathPrefix = gcsBasePathPrefix + "/" + topicName + "/" + getFormattedDatePrefix(Instant.now()) + "/";
+            final String pathPrefix = String.format("%s/%s/%s/", gcsBasePathPrefix, topicName, getFormattedDatePrefix(Instant.now()));
             final BlobId blobId = BlobId.of(gcsBucket, pathPrefix + fileName);
             final Map<String, String> metaDataMap = new HashMap<>();
             metaDataMap.put("topic", topicName);

--- a/src/test/java/com/gojek/beast/sink/dlq/GCSInvalidMessagesWrapperTest.java
+++ b/src/test/java/com/gojek/beast/sink/dlq/GCSInvalidMessagesWrapperTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertTrue;
 public class GCSInvalidMessagesWrapperTest {
 
     @Test
-    public void testMessagesCouldBeAdded() throws IOException {
+    public void testMessagesCouldBeAdded() {
         // encode message
         GCSInvalidMessagesWrapper msgWrapper = new GCSInvalidMessagesWrapper(new ObjectMapper(), new ArrayList<>());
         Map<String, Object> columns = new HashMap<>();

--- a/src/test/java/com/gojek/beast/sink/dlq/GCSwriterTest.java
+++ b/src/test/java/com/gojek/beast/sink/dlq/GCSwriterTest.java
@@ -8,7 +8,6 @@ import com.gojek.beast.models.Record;
 import com.gojek.beast.models.Status;
 import com.gojek.beast.sink.bq.BaseBQTest;
 import com.gojek.beast.sink.dlq.gcs.GCSErrorWriter;
-import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
@@ -17,8 +16,6 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -33,20 +30,14 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class GCSwriterTest extends BaseBQTest {
 
-    @Captor
-    private ArgumentCaptor<BlobInfo> createObjCaptor;
     @Mock
     private Clock clock;
     private GCSErrorWriter errorWriter;
     @Mock
     private Storage gcsStoreMock;
-    @Mock
-    private Blob blobMock;
-    private long nowMillis;
 
     @Before
     public void setUp() {
-        nowMillis = Instant.now().toEpochMilli();
         errorWriter = new GCSErrorWriter(gcsStoreMock, "test-bucket", "test-integ-beast");
     }
 


### PR DESCRIPTION
Simplified how ConsumerRecordConverter is converting raw bytes to columns.